### PR TITLE
Futures are now async coroutines

### DIFF
--- a/app/src/main/java/com/amaze/filepreloaderlibrary/sampleapp/MainActivity.kt
+++ b/app/src/main/java/com/amaze/filepreloaderlibrary/sampleapp/MainActivity.kt
@@ -68,7 +68,7 @@ class MainActivity : AppCompatActivity(), ActivityCompat.OnRequestPermissionsRes
 
             adapter.addAll(fileList)
 
-            timeView.text = "${timeDelta}ms\n------------ FILES IN ${externalDir.absolutePath} ------------"
+            timeView.text = "${timeDelta}ms\n---- FILES IN ${externalDir.absolutePath} (${it.size}) ----"
         }
     }
 

--- a/lib/src/main/java/com/amaze/filepreloaderlibrary/Constants.kt
+++ b/lib/src/main/java/com/amaze/filepreloaderlibrary/Constants.kt
@@ -15,14 +15,6 @@ const val DIVIDER = "/"
  */
 const val PRIORITY_NOW = 0
 /**
- * Load "NEXT immediately", used for thing that are to be shown after 1/60s
- */
-const val PRIORITY_NEXT = 1
-/**
  * Probably will need to be loaded in the FUTURE
  */
-const val PRIORITY_FUTURE = 2
-/**
- * There is some small probability this will need to be shown
- */
-const val PRIORITY_POSSIBLY = 3
+const val PRIORITY_FUTURE = 1

--- a/lib/src/main/java/com/amaze/filepreloaderlibrary/FetcherFunction.kt
+++ b/lib/src/main/java/com/amaze/filepreloaderlibrary/FetcherFunction.kt
@@ -1,9 +1,6 @@
 package com.amaze.filepreloaderlibrary
 
 /**
- * This class is a more legible version of `f: (String) -> D` that can be called with [process]
- * instead of invoke.
+ * This class is a more legible version of `f: (String) -> D`
  */
-class FetcherFunction<out D: DataContainer> (private val f: (String) -> D) {
-    internal fun process(path: String) = f(path)
-}
+typealias FetcherFunction<D> = (String) -> D

--- a/lib/src/main/java/com/amaze/filepreloaderlibrary/FilePreloader.kt
+++ b/lib/src/main/java/com/amaze/filepreloaderlibrary/FilePreloader.kt
@@ -24,8 +24,8 @@ object FilePreloader {
      *
      * @see [PreloadedManager].
      */
-    inline fun <reified D: DataContainer>with(noinline f: (String) -> D): SpecializedPreloader<D> {
-        val v = SpecializedPreloader(D::class.java, FetcherFunction(f))
+    inline fun <reified D: DataContainer>with(noinline f: FetcherFunction<D>): SpecializedPreloader<D> {
+        val v = SpecializedPreloader(D::class.java, f)
         weakList.add(WeakReference(v))
         return v
     }

--- a/lib/src/main/java/com/amaze/filepreloaderlibrary/FilePreloader.kt
+++ b/lib/src/main/java/com/amaze/filepreloaderlibrary/FilePreloader.kt
@@ -49,8 +49,10 @@ object FilePreloader {
      * Clear everything, all metadata loaded will be discarded.
      */
     fun cleanUp() {
-        weakList.forEach {
-            it.get()?.clear()
+        launch {
+            weakList.forEach {
+                it.get()?.clear()
+            }
         }
     }
 }

--- a/lib/src/main/java/com/amaze/filepreloaderlibrary/PreloadableUnit.kt
+++ b/lib/src/main/java/com/amaze/filepreloaderlibrary/PreloadableUnit.kt
@@ -1,0 +1,18 @@
+package com.amaze.filepreloaderlibrary
+
+import kotlinx.coroutines.experimental.Deferred
+
+internal data class PreloadableUnit<D: DataContainer>(val future: Deferred<ProcessedUnit<D>>, val priority: Int, val hash: Int): Comparable<PreloadableUnit<D>> {
+    override fun compareTo(other: PreloadableUnit<D>) = priority.compareTo(other.priority)
+    override fun hashCode() = hash
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as PreloadableUnit<*>
+
+        if (hash != other.hash) return false
+
+        return true
+    }
+}

--- a/lib/src/main/java/com/amaze/filepreloaderlibrary/Processor.kt
+++ b/lib/src/main/java/com/amaze/filepreloaderlibrary/Processor.kt
@@ -104,7 +104,7 @@ internal class Processor<D: DataContainer>(private val clazz: Class<D>) {
                 if (parentPath != null && getPreloadMap()[parentPath] == null) {
                     val subfiles: Array<String> = KFile(parentPath).list() ?: arrayOf()
                     subfiles.forEach {
-                        addToProcess(parentPath, ProcessUnit(parentPath + DIVIDER + it, unit.fetcherFunction), PRIORITY_POSSIBLY)
+                        addToProcess(parentPath, ProcessUnit(parentPath + DIVIDER + it, unit.fetcherFunction), PRIORITY_FUTURE)
                     }
 
                     getPreloadMap()[parentPath] = PreloadedFolder(subfiles.size)
@@ -162,7 +162,9 @@ internal class Processor<D: DataContainer>(private val clazz: Class<D>) {
      * Add file (represented by [unit]) to the [preloadPriorityQueue] to be preloaded by [work].
      */
     private fun addToProcess(path: String, unit: ProcessUnit<D>, priority: Int) {
-        val f = async { load(path, unit) }
+        val start = if(priority == PRIORITY_NOW) CoroutineStart.DEFAULT else CoroutineStart.LAZY
+
+        val f = async(start = start) { load(path, unit) }
         preloadPriorityQueue.add(PreloadableUnit(f, priority))
     }
 

--- a/lib/src/main/java/com/amaze/filepreloaderlibrary/Processor.kt
+++ b/lib/src/main/java/com/amaze/filepreloaderlibrary/Processor.kt
@@ -231,7 +231,7 @@ internal class Processor<D: DataContainer>(private val clazz: Class<D>) {
      * This loads every folder.
      */
     private fun load(path: String, unit: ProcessUnit<D>): ProcessedUnit<D> {
-        return ProcessedUnit(path, unit.fetcherFunction.process(unit.path))
+        return ProcessedUnit(path, unit.fetcherFunction(unit.path))
     }
 
     /**

--- a/lib/src/main/java/com/amaze/filepreloaderlibrary/SpecializedPreloader.kt
+++ b/lib/src/main/java/com/amaze/filepreloaderlibrary/SpecializedPreloader.kt
@@ -62,5 +62,5 @@ class SpecializedPreloader<out D: DataContainer>(private val clazz: Class<D>,
      * It's usage is not recommended as the [Processor] already has a more efficient cleaning
      * algorithm (see [Processor.deletionQueue]).
      */
-    internal fun clear() = processor.clear()
+    internal suspend fun clear() = processor.clear()
 }

--- a/lib/src/main/java/com/amaze/filepreloaderlibrary/SpecializedPreloader.kt
+++ b/lib/src/main/java/com/amaze/filepreloaderlibrary/SpecializedPreloader.kt
@@ -47,7 +47,7 @@ class SpecializedPreloader<out D: DataContainer>(private val clazz: Class<D>,
                 if (!path.endsWith(DIVIDER)) path += DIVIDER
 
                 val list = KFile(path).list()?.map {
-                    val data = fetcher.process(path + it)
+                    val data = fetcher(path + it)
                     Log.w("FilePreloader.Special", "Manually loaded $data!")
                     return@map data
                 } ?: listOf()

--- a/lib/src/main/java/com/amaze/filepreloaderlibrary/UniquePriorityBlockingQueue.kt
+++ b/lib/src/main/java/com/amaze/filepreloaderlibrary/UniquePriorityBlockingQueue.kt
@@ -1,0 +1,40 @@
+package com.amaze.filepreloaderlibrary
+
+import kotlinx.coroutines.experimental.sync.Mutex
+import kotlinx.coroutines.experimental.sync.withLock
+import java.util.*
+import java.util.concurrent.PriorityBlockingQueue
+import kotlin.collections.HashSet
+
+internal class UniquePriorityBlockingQueue<E: PreloadableUnit<*>> {
+    private val preloadPriorityQueue: PriorityBlockingQueue<E> = PriorityBlockingQueue()
+    private val containedCheck = Collections.synchronizedSet(HashSet<E>())
+    private val mutex = Mutex()
+
+    suspend fun add(element: E) = mutex.withLock {
+        if(containedCheck.contains(element)) {
+            preloadPriorityQueue.forEach {
+                if(it == element) {
+                    it.future.cancel()
+                }
+            }
+        } else {
+            containedCheck.add(element);
+        }
+
+        preloadPriorityQueue.add(element)
+    }
+
+    suspend fun poll(): E? = mutex.withLock {
+        val element = preloadPriorityQueue.poll()
+        containedCheck.remove(element)
+        return element
+    }
+
+    suspend fun clear() = mutex.withLock {
+        preloadPriorityQueue.clear()
+        preloadPriorityQueue.clear()
+    }
+
+    fun isNotEmpty() = containedCheck.isNotEmpty()
+}


### PR DESCRIPTION
* Used Referred future instead of normal lambda
* Implemented priorities as 'LAZY' and 'DEFAULT' start configs for futures
* FetcherFunction is now a typealias instead of a class
* Tell the amount of files loaded in the sample app
* Futures replaced are now canceled in loading queue `Processor.preloadPriorityQueue`
* Not start working if another coroutine is already working 